### PR TITLE
Use thumbnail to generate the blurhash

### DIFF
--- a/server/bootstrap.js
+++ b/server/bootstrap.js
@@ -9,6 +9,10 @@ module.exports = ({ strapi }) => {
     const port = strapi.config.get('server.port', 1337);
     console.log(`server config - host: ${host}, port: ${port}`);
 
+    // Use the thumbnail instead for faster processing (10+ MB images could take around 40-60s)
+    // TODO: add config to choose what format to use (with fallbacks)
+    const url = data.formats?.thumbnail?.url || data.url;
+
     if ((data.mime && data.mime.startsWith('image/'))) {
       let fullUrl = "";
       if (data.url.startsWith('http')) {


### PR DESCRIPTION
Can use the thumbnail to generate the hash for faster processing. A large image (10MB +) may take around 60s to process. Can be added as config option.